### PR TITLE
Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,42 @@
+# syntax=docker/dockerfile:1
+
+# Build
+#   docker build --tag=fcs-endpoint-tester .
+
+# Run
+#   docker run -p 8080:8080 fcs-endpoint-tester
+
+# ---------------------------------------------------------------------------
+FROM maven:3.8.6-jdk-8 AS deps
+
+WORKDIR /work
+
+RUN git clone --depth 1 https://github.com/clarin-eric/fcs-sru-client.git && \
+    cd fcs-sru-client/ && \
+    rm -rf .git/ && \
+    mvn -q install && \
+    cd .. && \
+    rm -rf fcs-sru-client
+
+RUN git clone --depth 1 https://github.com/clarin-eric/fcs-simple-client.git && \
+    cd fcs-simple-client/ && \
+    rm -rf .git/ && \
+    mvn -q install && \
+    cd .. && \
+    rm -rf fcs-simple-client
+
+# ---------------------------------------------------------------------------
+FROM maven:3.8.6-jdk-8 AS war
+
+WORKDIR /work
+
+COPY --from=deps /root/.m2/repository/eu/clarin/sru /root/.m2/repository/eu/clarin/sru
+
+COPY . /work/
+
+RUN mvn package
+
+# ---------------------------------------------------------------------------
+FROM tomcat:8-jre8-temurin-jammy as run
+
+COPY --from=war /work/target/FCSEndpointTester*.war $CATALINA_HOME/webapps/ROOT.war

--- a/pom.xml
+++ b/pom.xml
@@ -269,12 +269,12 @@
     <repositories>
         <repository>
             <id>clarin</id>
-            <url>http://catalog.clarin.eu/ds/nexus/content/repositories/Clarin/</url>
+            <url>https://catalog.clarin.eu/ds/nexus/content/repositories/Clarin/</url>
         </repository>
 
         <repository>
             <id>vaadin-addons</id>
-            <url>http://maven.vaadin.com/vaadin-addons</url>
+            <url>https://maven.vaadin.com/vaadin-addons</url>
         </repository>
     </repositories>
 </project>


### PR DESCRIPTION
Add Dockerfile to simplify build process. Also allows easy deployment (testing) if docker is used.

Depends on #2 . Otherwise maven HTTP blocking needs to be removed, with e.g.
```Dockerfile
# fix: https://stackoverflow.com/questions/67833372/getting-blocked-mirror-for-repositories-maven-error-even-after-adding-mirrors
RUN sed -i 's/<mirrorOf>external:http:\*<\/mirrorOf>/<mirrorOf>external:dummy:\*<\/mirrorOf>/' /usr/share/maven/conf/settings.xml
```